### PR TITLE
switched from rem to vh

### DIFF
--- a/apps/nk-associates-frontend/components/navigation/sidebar.tsx
+++ b/apps/nk-associates-frontend/components/navigation/sidebar.tsx
@@ -52,7 +52,7 @@ const Sidebar: React.ForwardRefRenderFunction<HTMLDivElement, SidebarProps> = (
        
       `}
     >
-      <div className="2xl:text-[3.85rem] flex h-full flex-col items-center justify-center px-[2.125rem] py-[5.75rem] text-center font-metropolis-bold text-[2.5rem] md:px-[2.375rem] md:text-[3rem] lg:px-[2.625rem] lg:text-[2.5rem] xl:px-[2.75rem] xl:text-[3.2rem] 2xl:px-[3rem]">
+      <div className=" flex h-full flex-col items-center justify-center px-[2.125rem] py-[5.75rem] text-right font-metropolis-bold text-[5vh] lg:text-[5.5vh] md:px-[2.375rem]  lg:px-[2.625rem] xl:px-[2.75rem]  2xl:px-[3rem]">
         {menuList}
       </div>
     </div>


### PR DESCRIPTION
switched from using rem for text sizing to using vh to ensure size stays consistent across screens with different heights as well. No more overlap. Checked on all screens available in chrome dev tools as well